### PR TITLE
Update ruby version to >= 2.7.1

### DIFF
--- a/verse-http.gemspec
+++ b/verse-http.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary = "HTTP Server and Exposition Endpoint for the Verse framework"
   spec.description = "HTTP Server and Exposition Endpoint for the Verse framework"
   spec.homepage = "https://github.com/verse-rb/verse-http"
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = ">= 2.7.1"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/verse-rb/verse-http"


### PR DESCRIPTION
I would want to use this gem for my ruby 2.7.1 project.
```
Gem::Specification.new do |spec|
  ...
  spec.required_ruby_version = ">= 2.7.1"
  
  ...
end
```